### PR TITLE
instrument seqcounts

### DIFF
--- a/drivers/dma-buf/reservation.c
+++ b/drivers/dma-buf/reservation.c
@@ -263,11 +263,13 @@ int reservation_object_get_fences_rcu(struct reservation_object *obj,
 				nshared = krealloc(shared, sz, GFP_KERNEL);
 				if (nshared) {
 					shared = nshared;
+					read_seqcount_cancel(&obj->seq);
 					continue;
 				}
 
 				ret = -ENOMEM;
 				shared_count = 0;
+				read_seqcount_cancel(&obj->seq);
 				break;
 			}
 			shared = nshared;

--- a/fs/nfs/delegation.c
+++ b/fs/nfs/delegation.c
@@ -143,8 +143,11 @@ again:
 		err = nfs4_open_delegation_recall(ctx, state, stateid);
 		if (!err)
 			err = nfs_delegation_claim_locks(ctx, state, stateid);
-		if (!err && read_seqcount_retry(&sp->so_reclaim_seqcount, seq))
-			err = -EAGAIN;
+		if (!err) {
+			if (read_seqcount_retry(&sp->so_reclaim_seqcount, seq))
+				err = -EAGAIN;
+		} else
+			read_seqcount_cancel(&sp->so_reclaim_seqcount);
 		mutex_unlock(&sp->so_delegreturn_mutex);
 		put_nfs_open_context(ctx);
 		if (err != 0)

--- a/include/linux/cpuset.h
+++ b/include/linux/cpuset.h
@@ -118,6 +118,11 @@ static inline bool read_mems_allowed_retry(unsigned int seq)
 	return read_seqcount_retry(&current->mems_allowed_seq, seq);
 }
 
+static inline void read_mems_allowed_cancel(void)
+{
+	read_seqcount_cancel(&current->mems_allowed_seq);
+}
+
 static inline void set_mems_allowed(nodemask_t nodemask)
 {
 	unsigned long flags;
@@ -236,6 +241,8 @@ static inline bool read_mems_allowed_retry(unsigned int seq)
 {
 	return false;
 }
+
+static inline void read_mems_allowed_cancel(void) {}
 
 #endif /* !CONFIG_CPUSETS */
 

--- a/include/linux/ktsan.h
+++ b/include/linux/ktsan.h
@@ -65,6 +65,16 @@ void ktsan_mtx_post_lock(void *addr, bool write, bool try, bool success);
 void ktsan_mtx_pre_unlock(void *addr, bool write);
 void ktsan_mtx_post_unlock(void *addr, bool write);
 
+/*
+ * Begin/end of seqcount read critical section.
+ * Disables/enabled handling of memory reads, because reads inside of seqcount
+ * read critical section are inherently racy.
+ */
+void ktsan_seqcount_begin(const void *s);
+void ktsan_seqcount_end(const void *s);
+void ktsan_seqcount_ignore_begin(void);
+void ktsan_seqcount_ignore_end(void);
+
 void ktsan_thread_fence(ktsan_memory_order_t mo);
 
 void ktsan_atomic8_store(void *addr, u8 value, ktsan_memory_order_t mo);
@@ -153,9 +163,10 @@ static inline void ktsan_mtx_post_lock(void *addr, bool write, bool try,
 static inline void ktsan_mtx_pre_unlock(void *addr, bool write) {}
 static inline void ktsan_mtx_post_unlock(void *addr, bool write) {}
 
-static inline void ktsan_membar_acquire(void) {}
-static inline void ktsan_membar_release(void) {}
-static inline void ktsan_membar_acq_rel(void) {}
+static inline void ktsan_seqcount_begin(const void *s) {}
+static inline void ktsan_seqcount_end(const void *s) {}
+static inline void ktsan_seqcount_ignore_begin(void) {}
+static inline void ktsan_seqcount_ignore_end(void) {}
 
 /* ktsan_atomic* are not called in non-ktsan build. */
 /* ktsan_bitop* are not called in non-ktsan build. */

--- a/kernel/time/hrtimer.c
+++ b/kernel/time/hrtimer.c
@@ -1158,8 +1158,10 @@ bool hrtimer_active(const struct hrtimer *timer)
 		seq = raw_read_seqcount_begin(&cpu_base->seq);
 
 		if (timer->state != HRTIMER_STATE_INACTIVE ||
-		    cpu_base->running == timer)
+		    cpu_base->running == timer) {
+			read_seqcount_cancel(&cpu_base->seq);
 			return true;
+		}
 
 	} while (read_seqcount_retry(&cpu_base->seq, seq) ||
 		 cpu_base != READ_ONCE(timer->base->cpu_base));

--- a/mm/ktsan/Makefile
+++ b/mm/ktsan/Makefile
@@ -6,6 +6,7 @@ obj-y := access.o 		\
 	 memblock.o 		\
 	 report.o 		\
 	 shadow.o 		\
+	 spinlock.o		\
 	 stack.o 		\
 	 stat.o 		\
 	 sync_atomic.o 		\
@@ -29,6 +30,7 @@ CFLAGS_REMOVE_ktsan.o			= -pg -O0 -O1 -O2
 CFLAGS_REMOVE_memblock.o		= -pg -O0 -O1 -O2
 CFLAGS_REMOVE_report.o			= -pg -O0 -O1 -O2
 CFLAGS_REMOVE_shadow.o			= -pg -O0 -O1 -O2
+CFLAGS_REMOVE_spinlock.o                = -pg -O0 -O1 -O2
 CFLAGS_REMOVE_stack.o			= -pg -O0 -O1 -O2
 CFLAGS_REMOVE_stat.o			= -pg -O0 -O1 -O2
 CFLAGS_REMOVE_sync_atomic.o		= -pg -O0 -O1 -O2
@@ -52,6 +54,7 @@ CFLAGS_ktsan.o			= -O3
 CFLAGS_memblock.o		= -O3
 CFLAGS_report.o			= -O3
 CFLAGS_shadow.o			= -O3
+CFLAGS_spinlock.o               = -O3
 CFLAGS_stack.o			= -O3
 CFLAGS_stat.o			= -O3
 CFLAGS_sync_atomic.o		= -O3

--- a/mm/ktsan/access.c
+++ b/mm/ktsan/access.c
@@ -101,6 +101,9 @@ void kt_access(kt_thr_t *thr, uptr_t pc, uptr_t addr, size_t size, bool read)
 	kt_stat_inc(thr, read ? kt_stat_access_read : kt_stat_access_write);
 	kt_stat_inc(thr, kt_stat_access_size1 + size);
 
+	if (read && thr->read_disable_depth)
+		return;
+
 	slots = kt_shadow_get(addr);
 
 	if (!slots)

--- a/mm/ktsan/alloc.c
+++ b/mm/ktsan/alloc.c
@@ -30,7 +30,7 @@ void __init kt_cache_init(kt_cache_t *cache, size_t obj_size,
 	*(void **)obj = NULL;
 
 	cache->head = (void *)cache->base;
-	spin_lock_init(&cache->lock);
+	kt_spin_init(&cache->lock);
 }
 
 /* Only available during early boot. */
@@ -46,19 +46,19 @@ void *kt_cache_alloc(kt_cache_t *cache)
 {
 	void *obj;
 
-	spin_lock(&cache->lock);
+	kt_spin_lock(&cache->lock);
 	obj = cache->head;
 	if (obj)
 		cache->head = *(void **)obj;
-	spin_unlock(&cache->lock);
+	kt_spin_unlock(&cache->lock);
 
 	return obj;
 }
 
 void kt_cache_free(kt_cache_t *cache, void *obj)
 {
-	spin_lock(&cache->lock);
+	kt_spin_lock(&cache->lock);
 	*(void **)obj = cache->head;
 	cache->head = obj;
-	spin_unlock(&cache->lock);
+	kt_spin_unlock(&cache->lock);
 }

--- a/mm/ktsan/ktsan.c
+++ b/mm/ktsan/ktsan.c
@@ -413,6 +413,40 @@ void ktsan_mtx_post_unlock(void *addr, bool write)
 }
 EXPORT_SYMBOL(ktsan_mtx_post_unlock);
 
+
+void ktsan_seqcount_begin(const void *s)
+{
+	ENTER(false, true);
+	kt_seqcount_begin(thr, pc, (uptr_t)s);
+	LEAVE();
+}
+EXPORT_SYMBOL(ktsan_seqcount_begin);
+
+void ktsan_seqcount_end(const void *s)
+{
+	ENTER(false, true);
+	kt_seqcount_end(thr, pc, (uptr_t)s);
+	LEAVE();
+}
+EXPORT_SYMBOL(ktsan_seqcount_end);
+
+
+void ktsan_seqcount_ignore_begin(void)
+{
+	ENTER(false, true);
+	kt_seqcount_ignore_begin(thr, pc);
+	LEAVE();
+}
+EXPORT_SYMBOL(ktsan_seqcount_ignore_begin);
+
+void ktsan_seqcount_ignore_end(void)
+{
+	ENTER(false, true);
+	kt_seqcount_ignore_end(thr, pc);
+	LEAVE();
+}
+EXPORT_SYMBOL(ktsan_seqcount_ignore_end);
+
 void ktsan_thread_fence(ktsan_memory_order_t mo)
 {
 	ENTER(false, false);

--- a/mm/ktsan/ktsan.h
+++ b/mm/ktsan/ktsan.h
@@ -204,6 +204,7 @@ struct kt_thr_s {
 	kt_clk_t		release_clk;
 	kt_trace_t		trace;
 	int			call_depth;
+	int			read_disable_depth;
 	int			event_disable_depth;
 	int			report_disable_depth;
 	int			preempt_disable_depth;
@@ -211,6 +212,12 @@ struct kt_thr_s {
 	unsigned long		irq_flags_before_mtx;
 	struct list_head	quarantine_list; /* list entry */
 	struct list_head	percpu_list; /* list head */
+	/* List of currently "acquired" for reading seqcounts. */
+	uptr_t			seqcount[4];
+	/* Where the seqcounts were acquired (for debugging). */
+	uptr_t			seqcount_pc[4];
+	/* Ignore of all seqcount-related events. */
+	int			seqcount_ignore;
 #if KT_DEBUG
 	kt_stack_t		start_stack;
 	kt_time_t		last_event_disable_time;
@@ -356,6 +363,12 @@ void kt_mtx_post_lock(kt_thr_t *thr, uptr_t pc, uptr_t addr, bool wr, bool try,
 		      bool success);
 void kt_mtx_pre_unlock(kt_thr_t *thr, uptr_t pc, uptr_t addr, bool wr);
 void kt_mtx_post_unlock(kt_thr_t *thr, uptr_t pc, uptr_t addr, bool wr);
+
+void kt_seqcount_begin(kt_thr_t *thr, uptr_t pc, uptr_t addr);
+void kt_seqcount_end(kt_thr_t *thr, uptr_t pc, uptr_t addr);
+void kt_seqcount_ignore_begin(kt_thr_t *thr, uptr_t pc);
+void kt_seqcount_ignore_end(kt_thr_t *thr, uptr_t pc);
+void kt_seqcount_bug(kt_thr_t *thr, uptr_t addr, const char *what);
 
 void kt_thread_fence(kt_thr_t* thr, uptr_t pc, ktsan_memory_order_t mo);
 void kt_thread_fence_no_ktsan(void);

--- a/mm/ktsan/ktsan.h
+++ b/mm/ktsan/ktsan.h
@@ -32,7 +32,7 @@
 
 #define KT_SHADOW_TO_LONG(shadow) (*(long *)(&shadow))
 
-#define KT_DEBUG 1
+#define KT_DEBUG 0
 #define KT_DEBUG_TRACE 0
 
 typedef unsigned long	uptr_t;

--- a/mm/ktsan/report.c
+++ b/mm/ktsan/report.c
@@ -7,7 +7,7 @@
 
 #define MAX_FUNCTION_NAME_SIZE (128)
 
-DEFINE_SPINLOCK(kt_report_lock);
+static kt_spinlock_t kt_report_lock;
 
 unsigned long last;
 
@@ -120,10 +120,10 @@ void kt_report_race(kt_thr_t *new, kt_race_info_t *info)
 		}
 	}
 
-	spin_lock(&kt_report_lock);
+	kt_spin_lock(&kt_report_lock);
 
 	if (info->addr == last) {
-		spin_unlock(&kt_report_lock);
+		kt_spin_unlock(&kt_report_lock);
 		return;
 	}
 	last = info->addr;
@@ -187,5 +187,5 @@ void kt_report_race(kt_thr_t *new, kt_race_info_t *info)
 
 	kt_stat_inc(new, kt_stat_reports);
 
-	spin_unlock(&kt_report_lock);
+	kt_spin_unlock(&kt_report_lock);
 }

--- a/mm/ktsan/spinlock.c
+++ b/mm/ktsan/spinlock.c
@@ -1,0 +1,27 @@
+#include "ktsan.h"
+
+void kt_spin_init(kt_spinlock_t *l)
+{
+	l->state = 0;
+}
+
+void kt_spin_lock(kt_spinlock_t *l)
+{
+	for (;;) {
+		if (kt_atomic8_exchange_no_ktsan(&l->state, 1) == 0)
+			return;
+		while (kt_atomic8_load_no_ktsan(&l->state) != 0)
+			cpu_relax();
+	}
+}
+
+void kt_spin_unlock(kt_spinlock_t *l)
+{
+	kt_thread_fence_no_ktsan(ktsan_memory_order_release);
+	kt_atomic8_store_no_ktsan(&l->state, 0);
+}
+
+int kt_spin_is_locked(kt_spinlock_t *l)
+{
+	return kt_atomic8_load_no_ktsan(&l->state) != 0;
+}

--- a/mm/ktsan/sync.c
+++ b/mm/ktsan/sync.c
@@ -59,3 +59,83 @@ void kt_sync_release(kt_thr_t *thr, uptr_t pc, uptr_t addr)
 	kt_clk_acquire(&sync->clk, &thr->clk);
 	spin_unlock(&sync->tab.lock);
 }
+
+void kt_seqcount_begin(kt_thr_t *thr, uptr_t pc, uptr_t addr)
+{
+	int i;
+
+	if (thr->seqcount_ignore)
+		return;
+
+	/* Find a slot for this seqcount and store it. */
+	BUG_ON(addr == 0);
+	for (i = 0; i < ARRAY_SIZE(thr->seqcount); i++) {
+		if (thr->seqcount[i] == 0) {
+			thr->seqcount[i] = addr;
+			thr->seqcount_pc[i] = pc;
+			break;
+		}
+	}
+	if (i == ARRAY_SIZE(thr->seqcount))
+		kt_seqcount_bug(thr, addr, "seqcount overflow");
+
+	thr->read_disable_depth++;
+	if (thr->read_disable_depth > ARRAY_SIZE(thr->seqcount) + 1)
+		kt_seqcount_bug(thr, addr, "read_disable_depth overflow");
+}
+
+void kt_seqcount_end(kt_thr_t *thr, uptr_t pc, uptr_t addr)
+{
+	int i;
+
+	if (thr->seqcount_ignore)
+		return;
+
+	/* Find and remove the seqcount (reversed to support nested locks). */
+	BUG_ON(addr == 0);
+	for (i = ARRAY_SIZE(thr->seqcount) - 1; i >= 0; i--) {
+		if (thr->seqcount[i] == addr) {
+			thr->seqcount[i] = 0;
+			thr->seqcount_pc[i] = 0;
+			break;
+		}
+	}
+	if (i < 0)
+		kt_seqcount_bug(thr, addr, "seqcount is not acquired");
+
+	thr->read_disable_depth--;
+	if (thr->read_disable_depth < 0)
+		kt_seqcount_bug(thr, addr, "read_disable_depth underflow");
+}
+
+void kt_seqcount_ignore_begin(kt_thr_t *thr, uptr_t pc)
+{
+	// This is counter-measure against fs/namei.c.
+	BUG_ON(thr->seqcount_ignore);
+	thr->seqcount_ignore = 1;
+	thr->read_disable_depth++;
+	if (thr->read_disable_depth > ARRAY_SIZE(thr->seqcount) + 1)
+		kt_seqcount_bug(thr, 0, "read_disable_depth overflow");
+}
+
+void kt_seqcount_ignore_end(kt_thr_t *thr, uptr_t pc)
+{
+	BUG_ON(!thr->seqcount_ignore);
+	thr->seqcount_ignore = 0;
+	thr->read_disable_depth--;
+	if (thr->read_disable_depth < 0)
+		kt_seqcount_bug(thr, 0, "read_disable_depth underflow");
+}
+
+void kt_seqcount_bug(kt_thr_t *thr, uptr_t addr, const char *what)
+{
+	int i;
+
+	pr_err("kt_seqcount_bug: %s\n", what);
+	pr_err(" seqlock=%p read_disable_depth=%d\n",
+		(void*)addr, thr->read_disable_depth);
+	for (i = 0; i < ARRAY_SIZE(thr->seqcount); i++)
+		pr_err(" slot #%d: %p [<%p>] %pS\n", i, (void*)thr->seqcount[i],
+			(void*)thr->seqcount_pc[i], (void*)thr->seqcount_pc[i]);
+	BUG();
+}

--- a/mm/ktsan/sync_atomic.c
+++ b/mm/ktsan/sync_atomic.c
@@ -14,7 +14,7 @@ void kt_thread_fence(kt_thr_t* thr, uptr_t pc, ktsan_memory_order_t mo)
 	}
 
 	/* Do full fence despite the actual memory order. */
-	kt_thread_fence_no_ktsan();
+	kt_thread_fence_no_ktsan(mo);
 
 	if (mo == ktsan_memory_order_release ||
 	    mo == ktsan_memory_order_acq_rel) {
@@ -39,7 +39,7 @@ do {									\
 		kt_clk_tick(&thr->clk, thr->id);			\
 									\
 		/* Do full fence despite the actual memory order. */	\
-		kt_thread_fence_no_ktsan();				\
+		kt_thread_fence_no_ktsan(ktsan_memory_order_acquire);	\
 	} else if (read) {						\
 		kt_clk_acquire(&thr->acquire_clk, &sync->clk);		\
 		kt_trace_add_event(thr,					\
@@ -52,7 +52,7 @@ do {									\
 	if ((mo) == ktsan_memory_order_release ||			\
 	    (mo) == ktsan_memory_order_acq_rel) {			\
 		/* Do full fence despite the actual memory order. */	\
-		kt_thread_fence_no_ktsan();				\
+		kt_thread_fence_no_ktsan(ktsan_memory_order_release);	\
 									\
 		kt_clk_acquire(&sync->clk, &thr->clk);			\
 		kt_trace_add_event(thr,					\

--- a/mm/ktsan/sync_atomic_no_ktsan.c
+++ b/mm/ktsan/sync_atomic_no_ktsan.c
@@ -5,9 +5,21 @@
 
 #include <asm/barrier.h>
 
-void kt_thread_fence_no_ktsan(void)
+void kt_thread_fence_no_ktsan(ktsan_memory_order_t mo)
 {
-	mb();
+	switch (mo) {
+	case ktsan_memory_order_acquire:
+		rmb();
+		break;
+	case ktsan_memory_order_release:
+		wmb();
+		break;
+	case ktsan_memory_order_acq_rel:
+		mb();
+		break;
+	default:
+		break;
+	}
 }
 
 u8 kt_atomic8_load_no_ktsan(void *addr)

--- a/mm/ktsan/tab.c
+++ b/mm/ktsan/tab.c
@@ -18,7 +18,7 @@ void __init kt_tab_init(kt_tab_t *tab, unsigned size,
 
 	for (i = 0; i < size; i++) {
 		part = &tab->parts[i];
-		spin_lock_init(&part->lock);
+		kt_spin_init(&part->lock);
 		part->head = NULL;
 	}
 
@@ -46,7 +46,7 @@ static inline void *kt_part_access(kt_tab_t *tab, kt_tab_part_t *part,
 	/* Get object if exists. */
 	if (created == NULL && destroy == false) {
 		if (obj) {
-			spin_lock(&obj->lock);
+			kt_spin_lock(&obj->lock);
 			return obj;
 		}
 		return NULL;
@@ -60,7 +60,7 @@ static inline void *kt_part_access(kt_tab_t *tab, kt_tab_part_t *part,
 			else
 				prev->link = obj->link;
 
-			spin_lock(&obj->lock);
+			kt_spin_lock(&obj->lock);
 			return obj;
 		}
 		return NULL;
@@ -73,7 +73,7 @@ static inline void *kt_part_access(kt_tab_t *tab, kt_tab_part_t *part,
 			if (!obj)
 				return NULL;
 
-			spin_lock_init(&obj->lock);
+			kt_spin_init(&obj->lock);
 			obj->link = part->head;
 			part->head = obj;
 			obj->key = key;
@@ -83,7 +83,7 @@ static inline void *kt_part_access(kt_tab_t *tab, kt_tab_part_t *part,
 			*created = false;
 		}
 
-		spin_lock(&obj->lock);
+		kt_spin_lock(&obj->lock);
 		return obj;
 	}
 
@@ -116,7 +116,7 @@ void *kt_tab_access(kt_tab_t *tab, uptr_t key, bool *created, bool destroy)
 	hash = key % tab->size;
 	part = &tab->parts[hash];
 
-	spin_lock(&part->lock);
+	kt_spin_lock(&part->lock);
 
 	for (obj = part->head; obj != NULL; obj = obj->link)
 		BUG_ON((uptr_t)obj < PAGE_OFFSET);
@@ -126,7 +126,7 @@ void *kt_tab_access(kt_tab_t *tab, uptr_t key, bool *created, bool destroy)
 	for (obj = part->head; obj != NULL; obj = obj->link)
 		BUG_ON((uptr_t)obj < PAGE_OFFSET);
 
-	spin_unlock(&part->lock);
+	kt_spin_unlock(&part->lock);
 
 	return result;
 }

--- a/mm/ktsan/tests_noinst.c
+++ b/mm/ktsan/tests_noinst.c
@@ -27,54 +27,54 @@ void kt_test_hash_table(void)
 	obj = kt_tab_access(&ctx->test_tab, 7, &created, false);
 	BUG_ON(obj == NULL);
 	BUG_ON(created != true);
-	BUG_ON(!spin_is_locked(&obj->tab.lock));
-	spin_unlock(&obj->tab.lock);
+	BUG_ON(!kt_spin_is_locked(&obj->tab.lock));
+	kt_spin_unlock(&obj->tab.lock);
 
 	obj1 = kt_tab_access(&ctx->test_tab, 7, &created, false);
 	BUG_ON(obj1 != obj);
 	BUG_ON(created != false);
-	BUG_ON(!spin_is_locked(&obj1->tab.lock));
-	spin_unlock(&obj1->tab.lock);
+	BUG_ON(!kt_spin_is_locked(&obj1->tab.lock));
+	kt_spin_unlock(&obj1->tab.lock);
 
 	obj2 = kt_tab_access(&ctx->test_tab, 7 + 13, &created, false);
 	BUG_ON(obj2 == NULL);
 	BUG_ON(obj2 == obj1);
 	BUG_ON(created != true);
-	BUG_ON(!spin_is_locked(&obj2->tab.lock));
-	spin_unlock(&obj2->tab.lock);
+	BUG_ON(!kt_spin_is_locked(&obj2->tab.lock));
+	kt_spin_unlock(&obj2->tab.lock);
 
 	obj3 = kt_tab_access(&ctx->test_tab, 7 + 13, NULL, false);
 	BUG_ON(obj3 != obj2);
-	BUG_ON(!spin_is_locked(&obj3->tab.lock));
-	spin_unlock(&obj3->tab.lock);
+	BUG_ON(!kt_spin_is_locked(&obj3->tab.lock));
+	kt_spin_unlock(&obj3->tab.lock);
 
 	obj3 = kt_tab_access(&ctx->test_tab, 3, &created, false);
 	BUG_ON(obj3 == NULL);
 	BUG_ON(obj3 == obj1 || obj3 == obj2);
 	BUG_ON(created != true);
-	BUG_ON(!spin_is_locked(&obj3->tab.lock));
-	spin_unlock(&obj3->tab.lock);
+	BUG_ON(!kt_spin_is_locked(&obj3->tab.lock));
+	kt_spin_unlock(&obj3->tab.lock);
 
 	/* Accessing. */
 
 	obj = kt_tab_access(&ctx->test_tab, 7, NULL, false);
 	BUG_ON(obj == NULL);
 	BUG_ON(obj != obj1);
-	BUG_ON(!spin_is_locked(&obj->tab.lock));
-	spin_unlock(&obj->tab.lock);
+	BUG_ON(!kt_spin_is_locked(&obj->tab.lock));
+	kt_spin_unlock(&obj->tab.lock);
 
 	obj = kt_tab_access(&ctx->test_tab, 7 + 13, &created, false);
 	BUG_ON(obj == NULL);
 	BUG_ON(obj != obj2);
 	BUG_ON(created != false);
-	BUG_ON(!spin_is_locked(&obj->tab.lock));
-	spin_unlock(&obj->tab.lock);
+	BUG_ON(!kt_spin_is_locked(&obj->tab.lock));
+	kt_spin_unlock(&obj->tab.lock);
 
 	obj = kt_tab_access(&ctx->test_tab, 3, NULL, false);
 	BUG_ON(obj == NULL);
 	BUG_ON(obj != obj3);
-	BUG_ON(!spin_is_locked(&obj->tab.lock));
-	spin_unlock(&obj->tab.lock);
+	BUG_ON(!kt_spin_is_locked(&obj->tab.lock));
+	kt_spin_unlock(&obj->tab.lock);
 
 	obj = kt_tab_access(&ctx->test_tab, 4, NULL, false);
 	BUG_ON(obj != NULL);
@@ -84,22 +84,22 @@ void kt_test_hash_table(void)
 	obj = kt_tab_access(&ctx->test_tab, 3, NULL, true);
 	BUG_ON(obj == NULL);
 	BUG_ON(obj != obj3);
-	BUG_ON(!spin_is_locked(&obj3->tab.lock));
-	spin_unlock(&obj3->tab.lock);
+	BUG_ON(!kt_spin_is_locked(&obj3->tab.lock));
+	kt_spin_unlock(&obj3->tab.lock);
 	kt_cache_free(&ctx->test_tab.obj_cache, obj3);
 
 	obj = kt_tab_access(&ctx->test_tab, 7 + 13, NULL, true);
 	BUG_ON(obj == NULL);
 	BUG_ON(obj != obj2);
-	BUG_ON(!spin_is_locked(&obj2->tab.lock));
-	spin_unlock(&obj2->tab.lock);
+	BUG_ON(!kt_spin_is_locked(&obj2->tab.lock));
+	kt_spin_unlock(&obj2->tab.lock);
 	kt_cache_free(&ctx->test_tab.obj_cache, obj2);
 
 	obj = kt_tab_access(&ctx->test_tab, 7, NULL, true);
 	BUG_ON(obj == NULL);
 	BUG_ON(obj != obj1);
-	BUG_ON(!spin_is_locked(&obj1->tab.lock));
-	spin_unlock(&obj1->tab.lock);
+	BUG_ON(!kt_spin_is_locked(&obj1->tab.lock));
+	kt_spin_unlock(&obj1->tab.lock);
 	kt_cache_free(&ctx->test_tab.obj_cache, obj1);
 
 	pr_err("ktsan: end of test.\n");

--- a/mm/ktsan/trace.c
+++ b/mm/ktsan/trace.c
@@ -28,7 +28,7 @@ static inline void kt_trace_switch(kt_trace_t *trace, kt_time_t clock)
 	kt_part_header_t *header, *prev_header;
 	unsigned long beg, end;
 
-	spin_lock(&trace->lock);
+	kt_spin_lock(&trace->lock);
 
 	part = trace->position / KT_TRACE_PART_SIZE;
 	header = &trace->headers[part];
@@ -42,13 +42,13 @@ static inline void kt_trace_switch(kt_trace_t *trace, kt_time_t clock)
 
 	header->clock = clock;
 
-	spin_unlock(&trace->lock);
+	kt_spin_unlock(&trace->lock);
 }
 
 void kt_trace_init(kt_trace_t *trace)
 {
 	memset(trace, 0, sizeof(*trace));
-	spin_lock_init(&trace->lock);
+	kt_spin_init(&trace->lock);
 }
 
 void kt_trace_add_event(kt_thr_t *thr, kt_event_type_t type, uptr_t addr)
@@ -83,11 +83,11 @@ void kt_trace_restore_stack(kt_thr_t *thr, kt_time_t clock, kt_stack_t *stack)
 	part = (clock % KT_TRACE_SIZE) / KT_TRACE_PART_SIZE;
 	header = &trace->headers[part];
 
-	spin_lock(&trace->lock);
+	kt_spin_lock(&trace->lock);
 
 	if (header->clock > clock) {
 		stack->size = 0;
-		spin_unlock(&trace->lock);
+		kt_spin_unlock(&trace->lock);
 		return;
 	}
 
@@ -103,7 +103,7 @@ void kt_trace_restore_stack(kt_thr_t *thr, kt_time_t clock, kt_stack_t *stack)
 		stack->size++;
 	}
 
-	spin_unlock(&trace->lock);
+	kt_spin_unlock(&trace->lock);
 }
 
 void kt_trace_dump(kt_trace_t *trace, uptr_t beg, uptr_t end)

--- a/mm/mempolicy.c
+++ b/mm/mempolicy.c
@@ -2014,6 +2014,8 @@ retry_cpuset:
 out:
 	if (unlikely(!page && read_mems_allowed_retry(cpuset_mems_cookie)))
 		goto retry_cpuset;
+	if (page)
+		read_mems_allowed_cancel();
 	return page;
 }
 
@@ -2061,6 +2063,8 @@ retry_cpuset:
 
 	if (unlikely(!page && read_mems_allowed_retry(cpuset_mems_cookie)))
 		goto retry_cpuset;
+	if (page)
+		read_mems_allowed_cancel();
 
 	return page;
 }

--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -3226,6 +3226,8 @@ out:
 	 */
 	if (unlikely(!page && read_mems_allowed_retry(cpuset_mems_cookie)))
 		goto retry_cpuset;
+	if (page)
+		read_mems_allowed_cancel();
 
 	return page;
 }

--- a/net/core/dev.c
+++ b/net/core/dev.c
@@ -851,6 +851,7 @@ retry:
 	dev = dev_get_by_index_rcu(net, ifindex);
 	if (!dev) {
 		rcu_read_unlock();
+		read_seqcount_cancel(&devnet_rename_seq);
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Seqcount (and seqlock) read critical sections are inherently racy.
To avoid reporting races inside of read sections, we disable read handling.
In oreder to support that I had to add read_seqcount_cancel
function that denotes end of read crititcal section (when we abandon it).