### PR TITLE
fix seqcount instrumentation

### DIFF
--- a/fs/dcache.c
+++ b/fs/dcache.c
@@ -1188,6 +1188,8 @@ again:
 		break;
 	case D_WALK_QUIT:
 	case D_WALK_SKIP:
+		if (!(seq&1))
+			read_seqcount_cancel(&rename_lock.seqcount);
 		goto out_unlock;
 	case D_WALK_NORETRY:
 		retry = false;
@@ -1209,6 +1211,8 @@ resume:
 			break;
 		case D_WALK_QUIT:
 			spin_unlock(&dentry->d_lock);
+			if (!(seq&1))
+				read_seqcount_cancel(&rename_lock.seqcount);
 			goto out_unlock;
 		case D_WALK_NORETRY:
 			retry = false;
@@ -1240,7 +1244,7 @@ ascend:
 		spin_lock(&this_parent->d_lock);
 
 		/* might go back up the wrong parent if we have had a rename. */
-		if (need_seqretry(&rename_lock, seq))
+		if (need_seqretry_check(&rename_lock, seq))
 			goto rename_retry;
 		/* go into the first sibling still alive */
 		do {


### PR DESCRIPTION
The issue was with the following sequence:

read_seqbegin_or_lock(seq==0);
need_seqretry(seq==0);
read_seqbegin_or_lock(seq==1);
need_seqretry(seq==1);
done_seqretry(seq==1);

It left thread in seqcount critical section.

Make need_seqretry close critical section,
and done_seqretry does not affect state of critical section.