### PR TITLE
add suppression mechanism

### DIFF
--- a/mm/ktsan/Makefile
+++ b/mm/ktsan/Makefile
@@ -9,6 +9,7 @@ obj-y := access.o 		\
 	 spinlock.o		\
 	 stack.o 		\
 	 stat.o 		\
+	 supp.o			\
 	 sync_atomic.o 		\
 	 sync_atomic_no_ktsan.o \
 	 sync_mtx.o 		\
@@ -34,6 +35,7 @@ CFLAGS_REMOVE_shadow.o			= -pg -O0 -O1 -O2
 CFLAGS_REMOVE_spinlock.o                = -pg -O0 -O1 -O2
 CFLAGS_REMOVE_stack.o			= -pg -O0 -O1 -O2
 CFLAGS_REMOVE_stat.o			= -pg -O0 -O1 -O2
+CFLAGS_REMOVE_supp.o			= -pg -O0 -O1 -O2
 CFLAGS_REMOVE_sync_atomic.o		= -pg -O0 -O1 -O2
 CFLAGS_REMOVE_sync_atomic_no_ktsan.o	= -pg -O0 -O1 -O2
 CFLAGS_REMOVE_sync_mtx.o		= -pg -O0 -O1 -O2
@@ -59,6 +61,7 @@ CFLAGS_shadow.o			= -O3
 CFLAGS_spinlock.o               = -O3
 CFLAGS_stack.o			= -O3
 CFLAGS_stat.o			= -O3
+CFLAGS_supp.o			= -O3
 CFLAGS_sync_atomic.o		= -O3
 CFLAGS_sync_atomic_no_ktsan.o	= -O3
 CFLAGS_sync_mtx.o		= -O3

--- a/mm/ktsan/ktsan.c
+++ b/mm/ktsan/ktsan.c
@@ -154,6 +154,7 @@ void ktsan_init(void)
 
 	ctx->cpus = alloc_percpu(kt_cpu_t);
 	kt_stat_init();
+	kt_supp_init();
 	kt_tests_init();
 
 	/* These stats were not recorded in kt_thr_create. */

--- a/mm/ktsan/ktsan.h
+++ b/mm/ktsan/ktsan.h
@@ -395,7 +395,6 @@ void kt_seqcount_ignore_end(kt_thr_t *thr, uptr_t pc);
 void kt_seqcount_bug(kt_thr_t *thr, uptr_t addr, const char *what);
 
 void kt_thread_fence(kt_thr_t* thr, uptr_t pc, ktsan_memory_order_t mo);
-void kt_thread_fence_no_ktsan(ktsan_memory_order_t mo);
 
 void kt_atomic8_store(kt_thr_t *thr, uptr_t pc,
 		void *addr, u8 value, ktsan_memory_order_t mo);
@@ -455,6 +454,8 @@ int kt_atomic_fetch_clear_bit(kt_thr_t *thr, uptr_t pc,
 		void *addr, long nr, ktsan_memory_order_t mo);
 int kt_atomic_fetch_change_bit(kt_thr_t *thr, uptr_t pc,
 		void *addr, long nr, ktsan_memory_order_t mo);
+
+void kt_thread_fence_no_ktsan(ktsan_memory_order_t mo);
 
 void kt_atomic8_store_no_ktsan(void *addr, u8 value);
 void kt_atomic16_store_no_ktsan(void *addr, u16 value);
@@ -530,6 +531,10 @@ void kt_func_exit(kt_thr_t *thr);
 void kt_report_disable(kt_thr_t *thr);
 void kt_report_enable(kt_thr_t *thr);
 void kt_report_race(kt_thr_t *thr, kt_race_info_t *info);
+
+/* Suppressions. */
+void kt_supp_init(void);
+bool kt_supp_suppressed(unsigned long pc);
 
 /* Internal allocator. */
 

--- a/mm/ktsan/supp.c
+++ b/mm/ktsan/supp.c
@@ -1,0 +1,56 @@
+#include "ktsan.h"
+
+#include <linux/kernel.h>
+#include <linux/kallsyms.h>
+
+#ifndef CONFIG_KALLSYMS
+#error "KTSAN suppressions require CONFIG_KALLSYMS"
+#endif
+
+struct kt_supp_s {
+	const char *func;
+	unsigned long start;
+	unsigned long end;
+	unsigned hits;
+};
+typedef struct kt_supp_s kt_supp_t;
+
+static kt_supp_t suppressions[] = {
+	{"generic_fillattr"},		/* Non-atomic read/write of timespec. https://lkml.org/lkml/2015/8/28/400 */
+	{"atime_needs_update"},		/* Non-atomic read/write of timespec */
+	{"tcp_poll"},			/* Race on tp->rcv_nxt. Seems benign */
+	{"vm_stat_account"},		/* Race on mm->total_vm. Stat accounting */
+};
+
+void kt_supp_init(void)
+{
+	int res, i;
+	unsigned long pc, size, off;
+	kt_supp_t *s;
+
+	for (i = 0; i < ARRAY_SIZE(suppressions); i++) {
+		s = &suppressions[i];
+		pc = kallsyms_lookup_name(s->func);
+		BUG_ON(pc == 0);
+		size = off = 0;
+		res = kallsyms_lookup_size_offset(pc, &size, &off);
+		BUG_ON(!res || size == 0 || off != 0);
+		s->start = pc;
+		s->end = pc + size;
+	}
+}
+
+bool kt_supp_suppressed(unsigned long pc)
+{
+	int i;
+	kt_supp_t *s;
+
+	for (i = 0; i < ARRAY_SIZE(suppressions); i++) {
+		s = &suppressions[i];
+		if (pc >= s->start && pc < s->end) {
+			kt_atomic32_fetch_add_no_ktsan(&s->hits, 1);
+			return true;
+		}
+	}
+	return false;
+}


### PR DESCRIPTION
Suppressions allows to ignore report in particular top stack functions.
Useful for bugs that we don't know to fix.

Also improve report deduplication: don't produce reports with
the same top stack functions.