### PR TITLE
Drop the two sync objects with the most number of instances

### DIFF
--- a/include/linux/ktsan.h
+++ b/include/linux/ktsan.h
@@ -59,6 +59,7 @@ void ktsan_memblock_free(void *addr, unsigned long size);
 
 void ktsan_sync_acquire(void *addr);
 void ktsan_sync_release(void *addr);
+void ktsan_sync_drop(void *addr);
 
 void ktsan_mtx_pre_lock(void *addr, bool write, bool try);
 void ktsan_mtx_post_lock(void *addr, bool write, bool try, bool success);
@@ -156,6 +157,7 @@ static inline void ktsan_memblock_free(void *addr, unsigned long size) {}
 
 static inline void ktsan_sync_acquire(void *addr) {}
 static inline void ktsan_sync_release(void *addr) {}
+static inline void ktsan_sync_drop(void *addr) {}
 
 static inline void ktsan_mtx_pre_lock(void *addr, bool write, bool try) {}
 static inline void ktsan_mtx_post_lock(void *addr, bool write, bool try,

--- a/mm/ktsan/ktsan.c
+++ b/mm/ktsan/ktsan.c
@@ -352,6 +352,14 @@ void ktsan_sync_release(void *addr)
 }
 EXPORT_SYMBOL(ktsan_sync_release);
 
+void ktsan_sync_drop(void *addr)
+{
+	ENTER(false, false);
+	kt_sync_drop_and_free(thr, (uptr_t)addr);
+	LEAVE();
+}
+EXPORT_SYMBOL(ktsan_sync_drop);
+
 void ktsan_memblock_alloc(void *addr, unsigned long size)
 {
 	ENTER(false, true);

--- a/mm/ktsan/ktsan.h
+++ b/mm/ktsan/ktsan.h
@@ -383,7 +383,8 @@ bool kt_thr_event_enable(kt_thr_t *thr, uptr_t pc, unsigned long *flags);
 /* Synchronization. */
 
 kt_tab_sync_t *kt_sync_ensure_created(kt_thr_t *thr, uptr_t pc, uptr_t addr);
-void kt_sync_destroy(kt_thr_t *thr, uptr_t addr);
+void kt_sync_free(kt_thr_t *thr, uptr_t addr);
+void kt_sync_drop_and_free(kt_thr_t *thr, uptr_t addr);
 
 void kt_sync_acquire(kt_thr_t *thr, uptr_t pc, uptr_t addr);
 void kt_sync_release(kt_thr_t *thr, uptr_t pc, uptr_t addr);
@@ -514,6 +515,7 @@ void kt_percpu_list_clean(kt_thr_t *thr, uptr_t pc);
 
 uptr_t kt_memblock_addr(uptr_t addr);
 void kt_memblock_add_sync(kt_thr_t *thr, uptr_t addr, kt_tab_sync_t *sync);
+void kt_memblock_remove_sync(kt_thr_t *thr, uptr_t addr, kt_tab_sync_t *sync);
 void kt_memblock_alloc(kt_thr_t *thr, uptr_t pc, uptr_t addr, size_t size);
 void kt_memblock_free(kt_thr_t *thr, uptr_t pc, uptr_t addr, size_t size);
 


### PR DESCRIPTION
Both are page flags, ~500k instances each after running Trinity for ~5 minutes.
Dropping them doesn't seem to be resulted in false positives, though it's something to keep in mind.