### PR TITLE
fix instrumentation of smp_load_acquire

### DIFF
--- a/arch/x86/include/asm/barrier.h
+++ b/arch/x86/include/asm/barrier.h
@@ -136,10 +136,10 @@ do {									\
 	compiletime_assert_atomic_type(*___p1);				\
 									\
 	switch (sizeof(*___p1)) {					\
-	case 1: ___r = ktsan_atomic8_load(___p1, ktsan_memory_order_release); break;	\
-	case 2: ___r = ktsan_atomic16_load(___p1, ktsan_memory_order_release); break;	\
-	case 4: ___r = ktsan_atomic32_load(___p1, ktsan_memory_order_release); break;	\
-	case 8: ___r = ktsan_atomic64_load(___p1, ktsan_memory_order_release); break;	\
+	case 1: *(u8*)&___r = ktsan_atomic8_load(___p1, ktsan_memory_order_release); break;	\
+	case 2: *(u16*)&___r = ktsan_atomic16_load(___p1, ktsan_memory_order_release); break;	\
+	case 4: *(u32*)&___r = ktsan_atomic32_load(___p1, ktsan_memory_order_release); break;	\
+	case 8: *(u64*)&___r = ktsan_atomic64_load(___p1, ktsan_memory_order_release); break;	\
 	default: BUG(); break;						\
 	}								\
 									\


### PR DESCRIPTION
Compiler produced warnings about conversion
of an interger to a pointer.