### PR TITLE
Ignore frequently created sync objects

### DIFF
--- a/arch/x86/include/asm/pgtable_64.h
+++ b/arch/x86/include/asm/pgtable_64.h
@@ -13,6 +13,7 @@
 #include <asm/processor.h>
 #include <linux/bitops.h>
 #include <linux/threads.h>
+#include <linux/ktsan.h>
 
 extern pud_t level3_kernel_pgt[512];
 extern pud_t level3_ident_pgt[512];
@@ -86,7 +87,14 @@ static inline pte_t native_ptep_get_and_clear(pte_t *xp)
 static inline pmd_t native_pmdp_get_and_clear(pmd_t *xp)
 {
 #ifdef CONFIG_SMP
-	return native_make_pmd(xchg(&xp->pmd, 0));
+	/* Make KTSAN ignore xchg.
+	   This significantly reduces the number of sync objects.
+	   This might introduce false positives, but none were observed. */
+	pmd_t rv;
+	ktsan_thr_event_disable();
+	rv = native_make_pmd(xchg(&xp->pmd, 0));
+	ktsan_thr_event_enable();
+	return rv;
 #else
 	/* native_local_pmdp_get_and_clear,
 	   but duplicated because of cyclic dependency */

--- a/include/linux/ktsan.h
+++ b/include/linux/ktsan.h
@@ -59,7 +59,6 @@ void ktsan_memblock_free(void *addr, unsigned long size);
 
 void ktsan_sync_acquire(void *addr);
 void ktsan_sync_release(void *addr);
-void ktsan_sync_drop(void *addr);
 
 void ktsan_mtx_pre_lock(void *addr, bool write, bool try);
 void ktsan_mtx_post_lock(void *addr, bool write, bool try, bool success);
@@ -157,7 +156,6 @@ static inline void ktsan_memblock_free(void *addr, unsigned long size) {}
 
 static inline void ktsan_sync_acquire(void *addr) {}
 static inline void ktsan_sync_release(void *addr) {}
-static inline void ktsan_sync_drop(void *addr) {}
 
 static inline void ktsan_mtx_pre_lock(void *addr, bool write, bool try) {}
 static inline void ktsan_mtx_post_lock(void *addr, bool write, bool try,

--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -383,6 +383,10 @@ static struct task_struct *dup_task_struct(struct task_struct *orig)
 
 	account_kernel_stack(ti, 1);
 
+#ifdef CONFIG_KTSAN
+	tsk->ktsan.thr = NULL;
+#endif
+
 	return tsk;
 
 free_ti:
@@ -1300,10 +1304,6 @@ static struct task_struct *copy_process(unsigned long clone_flags,
 	p = dup_task_struct(current);
 	if (!p)
 		goto fork_out;
-
-#ifdef CONFIG_KTSAN
-	p->ktsan.thr = NULL;
-#endif
 
 	ftrace_graph_init_task(p);
 

--- a/mm/ktsan/ktsan.c
+++ b/mm/ktsan/ktsan.c
@@ -341,14 +341,6 @@ void ktsan_sync_release(void *addr)
 }
 EXPORT_SYMBOL(ktsan_sync_release);
 
-void ktsan_sync_drop(void *addr)
-{
-	ENTER(false, false);
-	kt_sync_drop_and_free(thr, (uptr_t)addr);
-	LEAVE();
-}
-EXPORT_SYMBOL(ktsan_sync_drop);
-
 void ktsan_memblock_alloc(void *addr, unsigned long size)
 {
 	ENTER(false, true);

--- a/mm/ktsan/ktsan.h
+++ b/mm/ktsan/ktsan.h
@@ -484,7 +484,6 @@ bool kt_thr_event_enable(kt_thr_t *thr, uptr_t pc, unsigned long *flags);
 
 kt_tab_sync_t *kt_sync_ensure_created(kt_thr_t *thr, uptr_t pc, uptr_t addr);
 void kt_sync_free(kt_thr_t *thr, uptr_t addr);
-void kt_sync_drop_and_free(kt_thr_t *thr, uptr_t addr);
 
 void kt_sync_acquire(kt_thr_t *thr, uptr_t pc, uptr_t addr);
 void kt_sync_release(kt_thr_t *thr, uptr_t pc, uptr_t addr);

--- a/mm/ktsan/sync.c
+++ b/mm/ktsan/sync.c
@@ -47,26 +47,6 @@ void kt_sync_free(kt_thr_t *thr, uptr_t addr)
 	kt_stat_inc(thr, kt_stat_sync_free);
 }
 
-/* Remove sync object from hash table and memblock and frees it. */
-void kt_sync_drop_and_free(kt_thr_t *thr, uptr_t addr)
-{
-	kt_tab_sync_t *sync;
-	uptr_t memblock_addr;
-
-	sync = kt_tab_access(&kt_ctx.sync_tab, addr, NULL, true);
-	if (sync == NULL)
-		return;
-
-	memblock_addr = kt_memblock_addr(addr);
-	kt_memblock_remove_sync(thr, memblock_addr, sync);
-
-	kt_spin_unlock(&sync->tab.lock);
-	kt_cache_free(&kt_ctx.sync_tab.obj_cache, sync);
-
-	kt_stat_dec(thr, kt_stat_sync_objects);
-	kt_stat_inc(thr, kt_stat_sync_free);
-}
-
 void kt_sync_acquire(kt_thr_t *thr, uptr_t pc, uptr_t addr)
 {
 	kt_tab_sync_t *sync;

--- a/mm/ktsan/sync_mtx.c
+++ b/mm/ktsan/sync_mtx.c
@@ -29,7 +29,9 @@ void kt_mtx_post_lock(kt_thr_t *thr, uptr_t pc, uptr_t addr, bool wr, bool try,
 
 	/* FIXME(xairy): double tab access. */
 	sync = kt_tab_access(&kt_ctx.sync_tab, addr, NULL, false);
-	BUG_ON(sync == NULL);
+	if (sync == NULL)
+		return;
+
 	/* The following BUG_ON currently fails on scheduler rq lock.
 	 * Which is bad.
 	 */
@@ -52,7 +54,9 @@ void kt_mtx_pre_unlock(kt_thr_t *thr, uptr_t pc, uptr_t addr, bool wr)
 
 	/* FIXME(xairy): double tab access. */
 	sync = kt_tab_access(&kt_ctx.sync_tab, addr, NULL, false);
-	BUG_ON(sync == NULL);
+	if (sync == NULL)
+		return;
+
 	if (wr) {
 		BUG_ON(sync->lock_tid == -1);
 		if (wr && sync->lock_tid != thr->id)

--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -3281,13 +3281,7 @@ EXPORT_SYMBOL(get_zeroed_page);
 
 void __free_pages(struct page *page, unsigned int order)
 {
-	/* Dropping this sync object significantly reduces
-	   the total number of syncs objects (by ~500k).
-	   This can possibly lead to false positives, but
-	   we haven't observed any of them. */
-	int rv = put_page_testzero(page);
-	ktsan_sync_drop(&page->_count);
-	if (rv) {
+	if (put_page_testzero(page)) {
 		if (order == 0)
 			free_hot_cold_page(page, false);
 		else

--- a/mm/vmalloc.c
+++ b/mm/vmalloc.c
@@ -64,11 +64,6 @@ static void vunmap_pte_range(pmd_t *pmd, unsigned long addr, unsigned long end)
 	pte = pte_offset_kernel(pmd, addr);
 	do {
 		pte_t ptent = ptep_get_and_clear(&init_mm, addr, pte);
-		/* Dropping this sync object significantly reduces
-		   the total number of syncs objects (by ~500k).
-		   This can possibly lead to false positives, but
-		   we haven't observed any of them. */
-		ktsan_sync_drop(&pte->pte);
 		WARN_ON(!pte_none(ptent) && !pte_present(ptent));
 	} while (pte++, addr += PAGE_SIZE, addr != end);
 }


### PR DESCRIPTION
- Remove ktsan_sync_drop
- Do not create sync objects in page_structs
- Disable events around xchg in native_pmdp_get_and_clear