### PR TITLE
combine kt_percpu_release and kt_percpu_list_clean into a single function

### DIFF
--- a/mm/ktsan/ktsan.h
+++ b/mm/ktsan/ktsan.h
@@ -676,7 +676,6 @@ void kt_irq_restore(kt_thr_t *thr, uptr_t pc, unsigned long flags);
 
 void kt_percpu_acquire(kt_thr_t *thr, uptr_t pc, uptr_t addr);
 void kt_percpu_release(kt_thr_t *thr, uptr_t pc);
-void kt_percpu_list_clean(kt_thr_t *thr, uptr_t pc);
 
 /* Memory block allocation. */
 

--- a/mm/ktsan/thr.c
+++ b/mm/ktsan/thr.c
@@ -134,7 +134,6 @@ void kt_thr_stop(kt_thr_t *thr, uptr_t pc)
 	   (for example using might_sleep()). Therefore, percpu syncs won't
 	   be released before thread switching. Release them here. */
 	kt_percpu_release(thr, pc);
-	kt_percpu_list_clean(thr, pc);
 
 	thr->cpu = NULL;
 }


### PR DESCRIPTION
The are always called together. So this reduces code size and improves
performance as we walk the list only once.