### PR TITLE
Tick clock automatically and before adding event to trace

### DIFF
--- a/mm/ktsan/access.c
+++ b/mm/ktsan/access.c
@@ -129,9 +129,8 @@ void kt_access(kt_thr_t *thr, uptr_t pc, uptr_t addr, size_t size, bool read)
 	if (unlikely(!slots))
 		return; /* FIXME? */
 
-	current_clock = kt_clk_get(&thr->clk, thr->id);
 	kt_trace_add_event(thr, kt_event_mop, kt_compress(pc));
-	kt_clk_tick(&thr->clk, thr->id);
+	current_clock = kt_clk_get(&thr->clk, thr->id);
 
 	kt_access_impl(thr, slots, current_clock, addr, size, read);
 }
@@ -150,9 +149,8 @@ void kt_access_range(kt_thr_t *thr, uptr_t pc, uptr_t addr,
 	if (unlikely(!slots))
 		return; /* FIXME? */
 
-	current_clock = kt_clk_get(&thr->clk, thr->id);
 	kt_trace_add_event(thr, kt_event_mop, kt_compress(pc));
-	kt_clk_tick(&thr->clk, thr->id);
+	current_clock = kt_clk_get(&thr->clk, thr->id);
 
 	/* Handle unaligned beginning, if any. */
 	if (addr & (KT_GRAIN - 1)) {
@@ -178,6 +176,7 @@ void kt_access_range(kt_thr_t *thr, uptr_t pc, uptr_t addr,
 void kt_access_range_imitate(kt_thr_t *thr, uptr_t pc, uptr_t addr,
 				size_t size, bool read)
 {
+	kt_time_t current_clock;
 	kt_shadow_t value;
 	kt_shadow_t *slots;
 	int i;
@@ -192,13 +191,13 @@ void kt_access_range_imitate(kt_thr_t *thr, uptr_t pc, uptr_t addr,
 		return; /* FIXME? */
 
 	kt_trace_add_event(thr, kt_event_mop, kt_compress(pc));
-	kt_clk_tick(&thr->clk, thr->id);
+	current_clock = kt_clk_get(&thr->clk, thr->id);
 
 	/* Below we assume that access size 8 covers whole grain. */
 	BUG_ON(KT_GRAIN != (1 << KT_ACCESS_SIZE_8));
 
 	value.tid = thr->id;
-	value.clock = kt_clk_get(&thr->clk, thr->id);
+	value.clock = current_clock;
 	value.offset = 0;
 	value.size = KT_ACCESS_SIZE_8;
 	value.read = read;

--- a/mm/ktsan/func.c
+++ b/mm/ktsan/func.c
@@ -16,7 +16,6 @@ void kt_func_entry(kt_thr_t *thr, uptr_t pc)
 	kt_stat_inc(kt_stat_func_entry);
 
 	kt_trace_add_event(thr, kt_event_func_enter, kt_compress(pc));
-	kt_clk_tick(&thr->clk, thr->id);
 
 	kt_stack_push(&thr->stack, pc);
 
@@ -28,7 +27,6 @@ void kt_func_exit(kt_thr_t *thr)
 	kt_stat_inc(kt_stat_func_exit);
 
 	kt_trace_add_event(thr, kt_event_func_exit, 0);
-	kt_clk_tick(&thr->clk, thr->id);
 
 	kt_stack_pop(&thr->stack);
 

--- a/mm/ktsan/ktsan.h
+++ b/mm/ktsan/ktsan.h
@@ -535,6 +535,8 @@ void kt_trace_add_event(kt_thr_t *thr, kt_event_type_t type, u64 data)
 
 	kt_stat_inc(kt_stat_trace_event);
 
+	kt_clk_tick(&thr->clk, thr->id);
+
 	trace = &thr->trace;
 	clock = kt_clk_get(&thr->clk, thr->id);
 	pos = clock % KT_TRACE_SIZE;

--- a/mm/ktsan/mutexset.c
+++ b/mm/ktsan/mutexset.c
@@ -42,7 +42,6 @@ void kt_mutex_lock(kt_thr_t *thr, uptr_t pc, u64 sync_uid, bool write)
 	stack_handle = kt_stack_depot_save(&kt_ctx.stack_depot, &thr->stack);
 	kt_trace_add_event2(thr, write ? kt_event_lock : kt_event_rlock,
 				sync_uid, stack_handle);
-	kt_clk_tick(&thr->clk, thr->id);
 	kt_mutexset_lock(&thr->mutexset, sync_uid, stack_handle, write);
 	kt_func_exit(thr);
 }
@@ -52,6 +51,5 @@ void kt_mutex_unlock(kt_thr_t *thr, u64 sync_uid, bool write)
 {
 	kt_trace_add_event(thr, write ? kt_event_unlock : kt_event_runlock,
 				sync_uid);
-	kt_clk_tick(&thr->clk, thr->id);
 	kt_mutexset_unlock(&thr->mutexset, sync_uid, write);
 }

--- a/mm/ktsan/sync.c
+++ b/mm/ktsan/sync.c
@@ -84,7 +84,6 @@ void kt_sync_acquire(kt_thr_t *thr, uptr_t pc, uptr_t addr)
 
 #if KT_DEBUG
 	kt_trace_add_event(thr, kt_event_acquire, kt_compress(pc));
-	kt_clk_tick(&thr->clk, thr->id);
 #endif /* KT_DEBUG */
 
 	sync = kt_sync_ensure_created(thr, pc, addr);
@@ -100,7 +99,6 @@ void kt_sync_release(kt_thr_t *thr, uptr_t pc, uptr_t addr)
 
 #if KT_DEBUG
 	kt_trace_add_event(thr, kt_event_release, kt_compress(pc));
-	kt_clk_tick(&thr->clk, thr->id);
 #endif /* KT_DEBUG */
 
 	sync = kt_sync_ensure_created(thr, pc, addr);

--- a/mm/ktsan/sync_atomic.c
+++ b/mm/ktsan/sync_atomic.c
@@ -11,7 +11,6 @@ void kt_thread_fence(kt_thr_t *thr, uptr_t pc, ktsan_memory_order_t mo)
 #if KT_DEBUG
 			kt_trace_add_event(thr, kt_event_membar_acquire,
 						kt_compress(pc));
-			kt_clk_tick(&thr->clk, thr->id);
 #endif
 			kt_clk_acquire(&thr->clk, &thr->acquire_clk);
 			kt_stat_inc(kt_stat_acquire);
@@ -25,7 +24,6 @@ void kt_thread_fence(kt_thr_t *thr, uptr_t pc, ktsan_memory_order_t mo)
 #if KT_DEBUG
 		kt_trace_add_event(thr, kt_event_membar_release,
 					kt_compress(pc));
-		kt_clk_tick(&thr->clk, thr->id);
 #endif
 		if (thr->release_active)
 			kt_clk_acquire(&thr->release_clk, &thr->clk);
@@ -56,7 +54,6 @@ static kt_tab_sync_t *kt_atomic_pre_op(kt_thr_t *thr, uptr_t pc, uptr_t addr,
 			return NULL;
 #if KT_DEBUG
 		kt_trace_add_event(thr, kt_event_release, kt_compress(pc));
-		kt_clk_tick(&thr->clk, thr->id);
 #endif /* KT_DEBUG */
 		kt_release(thr, pc, sync);
 	} else if (write) {
@@ -68,7 +65,6 @@ static kt_tab_sync_t *kt_atomic_pre_op(kt_thr_t *thr, uptr_t pc, uptr_t addr,
 #if KT_DEBUG
 			kt_trace_add_event(thr, kt_event_nonmat_release,
 						kt_compress(pc));
-			kt_clk_tick(&thr->clk, thr->id);
 #endif /* KT_DEBUG */
 			kt_clk_acquire(&sync->clk, &thr->release_clk);
 			kt_stat_inc(kt_stat_release);
@@ -95,14 +91,12 @@ static kt_tab_sync_t *kt_atomic_post_op(kt_thr_t *thr, uptr_t pc, uptr_t addr,
 	    mo == ktsan_memory_order_acq_rel) {
 #if KT_DEBUG
 		kt_trace_add_event(thr, kt_event_acquire, kt_compress(pc));
-		kt_clk_tick(&thr->clk, thr->id);
 #endif /* KT_DEBUG */
 		kt_acquire(thr, pc, sync);
 	} else if (read) {
 #if KT_DEBUG
 		kt_trace_add_event(thr, kt_event_nonmat_acquire,
 					kt_compress(pc));
-		kt_clk_tick(&thr->clk, thr->id);
 #endif /* KT_DEBUG */
 		if (thr->acquire_active)
 			kt_clk_acquire(&thr->acquire_clk, &sync->clk);

--- a/mm/ktsan/sync_percpu.c
+++ b/mm/ktsan/sync_percpu.c
@@ -55,7 +55,6 @@ void kt_preempt_add(kt_thr_t *thr, uptr_t pc, int value)
 {
 #if KT_DEBUG
 	kt_trace_add_event(thr, kt_event_preempt_disable, kt_compress(pc));
-	kt_clk_tick(&thr->clk, thr->id);
 #endif /* KT_DEBUG */
 
 	thr->preempt_disable_depth += value;
@@ -65,7 +64,6 @@ void kt_preempt_sub(kt_thr_t *thr, uptr_t pc, int value)
 {
 #if KT_DEBUG
 	kt_trace_add_event(thr, kt_event_preempt_enable, kt_compress(pc));
-	kt_clk_tick(&thr->clk, thr->id);
 #endif /* KT_DEBUG */
 
 	thr->preempt_disable_depth -= value;
@@ -77,7 +75,6 @@ void kt_irq_disable(kt_thr_t *thr, uptr_t pc)
 {
 #if KT_DEBUG
 	kt_trace_add_event(thr, kt_event_irq_disable, kt_compress(pc));
-	kt_clk_tick(&thr->clk, thr->id);
 #endif /* KT_DEBUG */
 
 	thr->irqs_disabled = true;
@@ -87,7 +84,6 @@ void kt_irq_enable(kt_thr_t *thr, uptr_t pc)
 {
 #if KT_DEBUG
 	kt_trace_add_event(thr, kt_event_irq_enable, kt_compress(pc));
-	kt_clk_tick(&thr->clk, thr->id);
 #endif /* KT_DEBUG */
 
 	thr->irqs_disabled = false;


### PR DESCRIPTION
1. Tick clock automatically.
2. Now current thread clock points to the last trace event, not to the one after it.

P.S. The second change is actually required to write a failing test for kt_access in atomics (see #99), otherwise, when we do a release before an atomic store, the current thread clock is 1 higher and points to the following kt_access, and, as a result, doesn't race with a plain access after an atomic acquire in another thread. :)