### PR TITLE
Fix comparing unsigned with 0 in atomic.h

### DIFF
--- a/arch/x86/include/asm/atomic.h
+++ b/arch/x86/include/asm/atomic.h
@@ -185,7 +185,7 @@ static __always_inline int atomic_add_negative(int i, atomic_t *v)
 #ifndef CONFIG_KTSAN
 	GEN_BINARY_RMWcc(LOCK_PREFIX "addl", v->counter, "er", i, "%0", "s");
 #else
-	return (ktsan_atomic32_fetch_add((void *)v, i,
+	return ((int)ktsan_atomic32_fetch_add((void *)v, i,
 			ktsan_memory_order_acq_rel) + i) < 0;
 #endif
 }

--- a/arch/x86/include/asm/atomic64_64.h
+++ b/arch/x86/include/asm/atomic64_64.h
@@ -181,7 +181,7 @@ static inline int atomic64_add_negative(long i, atomic64_t *v)
 #ifndef CONFIG_KTSAN
 	GEN_BINARY_RMWcc(LOCK_PREFIX "addq", v->counter, "er", i, "%0", "s");
 #else
-	return (ktsan_atomic64_fetch_add((void *)v, i,
+	return ((long)ktsan_atomic64_fetch_add((void *)v, i,
 			ktsan_memory_order_acq_rel) + i) < 0;
 #endif
 }


### PR DESCRIPTION
We don't have to add casts to signed type when doing == 0, but we have to when doing < 0.